### PR TITLE
feat: configurable Prometheus discovery via plugin settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ The plugin gracefully degrades when the GpuDevicePlugin CRD is not installed —
 - Resource prefix: `gpu.intel.com/`
 - Node labels: `intel.feature.node.kubernetes.io/gpu`, `node-role.kubernetes.io/gpu`, `node-role.kubernetes.io/igpu`
 - Pod selector: `app=intel-gpu-plugin`
-- Prometheus services: `kube-prometheus-stack-prometheus`, `prometheus-operated`, `prometheus` (monitoring namespace, port 9090)
+- Prometheus services: `kube-prometheus-stack-prometheus`, `prometheus-operated`, `prometheus` (monitoring namespace, port 9090) — configurable via plugin settings (see `src/api/pluginConfig.ts`)
 
 ## Code conventions
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ Search for `headlamp-intel-gpu` in the Headlamp Plugin Manager (Settings → Plu
 - Optional: Node Feature Discovery with Intel GPU labels
 - Optional: kube-prometheus-stack with node-exporter for GPU power metrics
 
+## Configuration
+
+### Prometheus Service Discovery
+
+By default, the Metrics page discovers Prometheus by trying the following
+in-cluster services (in order):
+
+1. `monitoring/kube-prometheus-stack-prometheus:9090`
+2. `monitoring/prometheus-operated:9090`
+3. `monitoring/prometheus:9090`
+
+If your Prometheus is deployed in a different namespace or uses a different
+service name (e.g. `observability/monitoring-kube-prometheus-prometheus:9090`),
+configure it via the plugin settings page:
+
+**Settings → Plugins → intel-gpu**
+
+Set the **Prometheus Namespace**, **Prometheus Service Name**, and
+**Prometheus Port** fields. The configured service is tried first; if it is
+unreachable, the plugin falls back to the built-in default candidates. Leave
+all fields blank to use the defaults (backward-compatible with v1.1.0).
+
 ## RBAC
 
 This plugin is **read-only** and requires the following permissions:
@@ -50,6 +72,7 @@ src/
 ├── api/
 │   ├── k8s.ts                   # Types and helper functions
 │   ├── metrics.ts               # Prometheus GPU metrics
+│   ├── pluginConfig.ts          # ConfigStore-based plugin settings
 │   └── IntelGpuDataContext.tsx  # React context provider
 └── components/
     ├── OverviewPage.tsx          # Dashboard
@@ -57,6 +80,7 @@ src/
     ├── NodesPage.tsx             # GPU nodes
     ├── PodsPage.tsx              # GPU pods
     ├── MetricsPage.tsx           # Power metrics
+    ├── SettingsPage.tsx          # Plugin settings (Prometheus discovery)
     ├── NodeDetailSection.tsx     # Injected into Node detail view
     ├── PodDetailSection.tsx      # Injected into Pod detail view
     └── integrations/
@@ -79,7 +103,7 @@ npm run lint       # ESLint
 |---------|-------|-----|
 | No GPU nodes shown | No Intel GPU labels or resources on nodes | Install Intel Node Feature Discovery or Intel GPU device plugin |
 | CRD not available warning | GpuDevicePlugin CRD not installed | Install Intel device plugins operator — plugin still works without it |
-| No metrics data | Prometheus not found | Deploy kube-prometheus-stack in the `monitoring` namespace |
+| No metrics data | Prometheus not found | Deploy kube-prometheus-stack, or configure the Prometheus namespace/service via Settings → Plugins → intel-gpu |
 | Metrics show only discrete GPUs | Integrated GPUs lack hwmon | Expected — iGPU driver doesn't expose hwmon power data |
 
 ## Contributing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ This plugin is **read-only**. It does not perform any write operations against t
 - Nodes
 - Pods (all namespaces)
 - GpuDevicePlugin CRDs (`deviceplugin.intel.com/v1`)
-- Prometheus metrics (via API proxy in `monitoring` namespace)
+- Prometheus metrics (via API proxy; namespace/service is configurable via plugin settings, defaults to `monitoring` namespace)
 
 All data is fetched through Headlamp's built-in API proxy, which respects the user's existing RBAC permissions.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intel-gpu",
-  "version": "1.1.0",
+  "version": "1.2.0-lab226",
   "description": "Headlamp plugin for Intel GPU device plugin visibility and monitoring",
   "repository": {
     "type": "git",

--- a/src/api/metrics.test.ts
+++ b/src/api/metrics.test.ts
@@ -1,0 +1,339 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock ApiProxy before importing modules that depend on it
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ApiProxy: { request: vi.fn() },
+  ConfigStore: vi.fn().mockImplementation(() => ({
+    get: vi.fn(() => ({})),
+    set: vi.fn(),
+    update: vi.fn(),
+    useConfig: vi.fn(() => () => ({})),
+  })),
+}));
+
+import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { fetchGpuMetrics, getCheckedServicesDescription } from './metrics';
+import {
+  DEFAULT_PROMETHEUS_SERVICES,
+  getPrometheusServiceCandidates,
+  prometheusConfigStore,
+} from './pluginConfig';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockRequestFailure(): void {
+  vi.mocked(ApiProxy.request).mockRejectedValue(new Error('404 Not Found'));
+}
+
+function mockRequestWithChipResults(): void {
+  // Call 0: discovery check (findPrometheusPath) — returns success
+  // Calls 1-4: actual metric queries (chip, energy rate, power max, uname)
+  const calls: Record<number, unknown> = {
+    0: {
+      // discovery check — just needs status: success
+      status: 'success',
+      data: { resultType: 'vector', result: [] },
+    },
+    1: {
+      // chip identification query
+      status: 'success',
+      data: {
+        resultType: 'vector',
+        result: [
+          {
+            metric: { chip: '0000:09:01_0', instance: '10.0.0.1:9100', chip_name: 'i915' },
+            value: [1234567890, '1'],
+          },
+        ],
+      },
+    },
+    2: {
+      // energy rate query
+      status: 'success',
+      data: {
+        resultType: 'vector',
+        result: [
+          {
+            metric: { chip: '0000:09:01_0', instance: '10.0.0.1:9100' },
+            value: [1234567890, '45.3'],
+          },
+        ],
+      },
+    },
+    3: {
+      // power max query
+      status: 'success',
+      data: {
+        resultType: 'vector',
+        result: [
+          {
+            metric: { chip: '0000:09:01_0', instance: '10.0.0.1:9100' },
+            value: [1234567890, '120'],
+          },
+        ],
+      },
+    },
+    4: {
+      // uname query
+      status: 'success',
+      data: {
+        resultType: 'vector',
+        result: [
+          {
+            metric: { instance: '10.0.0.1:9100', nodename: 'gpu-node-1' },
+            value: [1234567890, '1'],
+          },
+        ],
+      },
+    },
+  };
+  let callIndex = 0;
+  vi.mocked(ApiProxy.request).mockImplementation(() => {
+    const result =
+      calls[callIndex] ?? { status: 'success', data: { resultType: 'vector', result: [] } };
+    callIndex++;
+    return Promise.resolve(result);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('metrics — pluginConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset config store to empty defaults
+    vi.mocked(prometheusConfigStore.get).mockReturnValue({
+      prometheusNamespace: '',
+      prometheusService: '',
+      prometheusPort: '',
+    });
+  });
+
+  describe('getPrometheusServiceCandidates — default behavior', () => {
+    it('returns only the built-in defaults when no config is set', () => {
+      const candidates = getPrometheusServiceCandidates();
+      // No custom config → only the 3 built-in defaults
+      expect(candidates).toHaveLength(3);
+      expect(candidates).toEqual([...DEFAULT_PROMETHEUS_SERVICES]);
+    });
+
+    it('includes the built-in kube-prometheus-stack-prometheus as first default', () => {
+      const candidates = getPrometheusServiceCandidates();
+      expect(candidates[0]).toEqual({
+        namespace: 'monitoring',
+        service: 'kube-prometheus-stack-prometheus',
+        port: '9090',
+      });
+    });
+
+    it('includes prometheus-operated as second default', () => {
+      const candidates = getPrometheusServiceCandidates();
+      expect(candidates[1]).toEqual({
+        namespace: 'monitoring',
+        service: 'prometheus-operated',
+        port: '9090',
+      });
+    });
+
+    it('includes prometheus as third default', () => {
+      const candidates = getPrometheusServiceCandidates();
+      expect(candidates[2]).toEqual({
+        namespace: 'monitoring',
+        service: 'prometheus',
+        port: '9090',
+      });
+    });
+  });
+
+  describe('getPrometheusServiceCandidates — custom config', () => {
+    it('prepends custom service when all three fields are configured', () => {
+      vi.mocked(prometheusConfigStore.get).mockReturnValue({
+        prometheusNamespace: 'observability',
+        prometheusService: 'monitoring-kube-prometheus-prometheus',
+        prometheusPort: '9090',
+      });
+      const candidates = getPrometheusServiceCandidates();
+      // Custom first, then 3 defaults = 4 total
+      expect(candidates).toHaveLength(4);
+      expect(candidates[0]).toEqual({
+        namespace: 'observability',
+        service: 'monitoring-kube-prometheus-prometheus',
+        port: '9090',
+      });
+    });
+
+    it('does not add custom candidate when only namespace is set', () => {
+      vi.mocked(prometheusConfigStore.get).mockReturnValue({
+        prometheusNamespace: 'observability',
+        prometheusService: '',
+        prometheusPort: '',
+      });
+      const candidates = getPrometheusServiceCandidates();
+      // Only defaults, since not all three fields are set
+      expect(candidates).toHaveLength(3);
+      expect(candidates[0].namespace).toBe('monitoring');
+    });
+
+    it('does not add custom candidate when only service is set', () => {
+      vi.mocked(prometheusConfigStore.get).mockReturnValue({
+        prometheusNamespace: '',
+        prometheusService: 'my-prometheus',
+        prometheusPort: '',
+      });
+      const candidates = getPrometheusServiceCandidates();
+      expect(candidates).toHaveLength(3);
+    });
+
+    it('preserves built-in defaults after custom candidate', () => {
+      vi.mocked(prometheusConfigStore.get).mockReturnValue({
+        prometheusNamespace: 'custom-ns',
+        prometheusService: 'custom-prom',
+        prometheusPort: '9091',
+      });
+      const candidates = getPrometheusServiceCandidates();
+      expect(candidates[0].namespace).toBe('custom-ns');
+      expect(candidates[1]).toEqual(DEFAULT_PROMETHEUS_SERVICES[0]);
+      expect(candidates[2]).toEqual(DEFAULT_PROMETHEUS_SERVICES[1]);
+      expect(candidates[3]).toEqual(DEFAULT_PROMETHEUS_SERVICES[2]);
+    });
+  });
+});
+
+describe('metrics — getCheckedServicesDescription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prometheusConfigStore.get).mockReturnValue({
+      prometheusNamespace: '',
+      prometheusService: '',
+      prometheusPort: '',
+    });
+  });
+
+  it('describes default services when no config is set', () => {
+    const desc = getCheckedServicesDescription();
+    expect(desc).toContain('kube-prometheus-stack-prometheus:9090');
+    expect(desc).toContain('monitoring namespace');
+  });
+
+  it('includes custom service in description when configured', () => {
+    vi.mocked(prometheusConfigStore.get).mockReturnValue({
+      prometheusNamespace: 'observability',
+      prometheusService: 'monitoring-kube-prometheus-prometheus',
+      prometheusPort: '9090',
+    });
+    const desc = getCheckedServicesDescription();
+    expect(desc).toContain('monitoring-kube-prometheus-prometheus:9090');
+    expect(desc).toContain('observability namespace');
+    // Still includes defaults
+    expect(desc).toContain('kube-prometheus-stack-prometheus:9090');
+  });
+});
+
+describe('metrics — fetchGpuMetrics discovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prometheusConfigStore.get).mockReturnValue({
+      prometheusNamespace: '',
+      prometheusService: '',
+      prometheusPort: '',
+    });
+  });
+
+  it('returns null when no Prometheus service is reachable (all defaults fail)', async () => {
+    mockRequestFailure();
+    const result = await fetchGpuMetrics();
+    expect(result).toBeNull();
+  });
+
+  it('queries default service candidates when no custom config is set', async () => {
+    mockRequestFailure();
+    await fetchGpuMetrics();
+    const calls = vi.mocked(ApiProxy.request).mock.calls;
+    // First call should be to the first default service (kube-prometheus-stack-prometheus)
+    const firstPath = calls[0][0] as string;
+    expect(firstPath).toContain('monitoring');
+    expect(firstPath).toContain('kube-prometheus-stack-prometheus');
+    expect(firstPath).toContain('9090');
+  });
+
+  it('queries custom service first when config is set', async () => {
+    vi.mocked(prometheusConfigStore.get).mockReturnValue({
+      prometheusNamespace: 'observability',
+      prometheusService: 'monitoring-kube-prometheus-prometheus',
+      prometheusPort: '9090',
+    });
+    mockRequestFailure();
+    await fetchGpuMetrics();
+    const calls = vi.mocked(ApiProxy.request).mock.calls;
+    // First call should be to the custom service
+    const firstPath = calls[0][0] as string;
+    expect(firstPath).toContain('observability');
+    expect(firstPath).toContain('monitoring-kube-prometheus-prometheus');
+  });
+
+  it('succeeds when custom service is reachable', async () => {
+    vi.mocked(prometheusConfigStore.get).mockReturnValue({
+      prometheusNamespace: 'observability',
+      prometheusService: 'monitoring-kube-prometheus-prometheus',
+      prometheusPort: '9090',
+    });
+    mockRequestWithChipResults();
+    const result = await fetchGpuMetrics();
+    expect(result).not.toBeNull();
+    expect(result!.chips).toHaveLength(1);
+    expect(result!.chips[0].nodeName).toBe('gpu-node-1');
+    expect(result!.chips[0].powerWatts).toBe(45.3);
+    expect(result!.chips[0].powerMaxWatts).toBe(120);
+  });
+
+  it('falls back to defaults when custom service fails', async () => {
+    vi.mocked(prometheusConfigStore.get).mockReturnValue({
+      prometheusNamespace: 'observability',
+      prometheusService: 'monitoring-kube-prometheus-prometheus',
+      prometheusPort: '9090',
+    });
+
+    // First call (custom service) fails, subsequent calls (defaults) succeed
+    let callCount = 0;
+    vi.mocked(ApiProxy.request).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // Custom service discovery check fails
+        return Promise.reject(new Error('404'));
+      }
+      // Default service discovery check succeeds, then return chip data
+      if (callCount === 2) {
+        return Promise.resolve({
+          status: 'success',
+          data: { resultType: 'vector', result: [] },
+        });
+      }
+      // Subsequent calls for actual metric queries
+      return Promise.resolve({
+        status: 'success',
+        data: { resultType: 'vector', result: [] },
+      });
+    });
+
+    const result = await fetchGpuMetrics();
+    expect(result).not.toBeNull();
+    // Should have tried custom first, then default
+    const calls = vi.mocked(ApiProxy.request).mock.calls;
+    const firstPath = calls[0][0] as string;
+    expect(firstPath).toContain('observability');
+    const secondPath = calls[1][0] as string;
+    expect(secondPath).toContain('monitoring');
+    expect(secondPath).toContain('kube-prometheus-stack-prometheus');
+  });
+
+  it('succeeds with default services when no custom config is set', async () => {
+    mockRequestWithChipResults();
+    const result = await fetchGpuMetrics();
+    expect(result).not.toBeNull();
+    expect(result!.chips).toHaveLength(1);
+  });
+});

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -13,6 +13,7 @@
  */
 
 import { ApiProxy } from '@kinvolk/headlamp-plugin/lib';
+import { getPrometheusServiceCandidates } from './pluginConfig';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -56,14 +57,16 @@ interface PrometheusResponse {
 
 /**
  * Service discovery: find the Prometheus service.
- * Tries the kube-prometheus-stack default name; falls back to prometheus-operated.
+ *
+ * Tries user-configured service first (if set via plugin settings), then
+ * falls back to the built-in default candidates (kube-prometheus-stack,
+ * prometheus-operated, prometheus — all in the monitoring namespace).
+ *
+ * The candidate list is built dynamically from ConfigStore settings so
+ * deployments using a non-default namespace/service (e.g. observability /
+ * monitoring-kube-prometheus-prometheus) can be supported without code
+ * changes.
  */
-const PROMETHEUS_SERVICES = [
-  { namespace: 'monitoring', service: 'kube-prometheus-stack-prometheus', port: '9090' },
-  { namespace: 'monitoring', service: 'prometheus-operated', port: '9090' },
-  { namespace: 'monitoring', service: 'prometheus', port: '9090' },
-];
-
 async function queryPrometheus(query: string, prometheusPath: string): Promise<PrometheusResult[]> {
   const encoded = encodeURIComponent(query);
   const path = `${prometheusPath}/api/v1/query?query=${encoded}`;
@@ -75,7 +78,8 @@ async function queryPrometheus(query: string, prometheusPath: string): Promise<P
 }
 
 async function findPrometheusPath(): Promise<string | null> {
-  for (const { namespace, service, port } of PROMETHEUS_SERVICES) {
+  const candidates = getPrometheusServiceCandidates();
+  for (const { namespace, service, port } of candidates) {
     const basePath = `/api/v1/namespaces/${namespace}/services/${service}:${port}/proxy`;
     try {
       const raw = (await ApiProxy.request(`${basePath}/api/v1/query?query=1`, {
@@ -87,6 +91,17 @@ async function findPrometheusPath(): Promise<string | null> {
     }
   }
   return null;
+}
+
+/**
+ * Returns a human-readable list of service candidates that were checked
+ * during discovery.  Used for error reporting in the Metrics page.
+ */
+export function getCheckedServicesDescription(): string {
+  const candidates = getPrometheusServiceCandidates();
+  return candidates
+    .map(({ namespace, service, port }) => `${service}:${port} (${namespace} namespace)`)
+    .join(', ');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/pluginConfig.ts
+++ b/src/api/pluginConfig.ts
@@ -1,0 +1,115 @@
+/**
+ * Plugin configuration for the intel-gpu Headlamp plugin.
+ *
+ * Uses Headlamp's ConfigStore API to persist user-configurable settings in
+ * the browser's Redux store.  The settings are editable via the plugin
+ * settings page (Settings → Plugins → intel-gpu) and readable at runtime
+ * from both React components (useConfig hook) and non-React code
+ * (get() method).
+ */
+
+import { ConfigStore } from '@kinvolk/headlamp-plugin/lib';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Prometheus service discovery configuration.
+ *
+ * All fields are optional — when unset (empty string), the plugin falls
+ * back to the built-in default service candidates, preserving backward
+ * compatibility with existing kube-prometheus-stack deployments.
+ */
+export interface PrometheusConfig {
+  /** Kubernetes namespace where Prometheus is deployed (e.g. "observability"). */
+  prometheusNamespace: string;
+  /** Kubernetes Service name for Prometheus (e.g. "monitoring-kube-prometheus-prometheus"). */
+  prometheusService: string;
+  /** Port number/name for the Prometheus service (e.g. "9090"). */
+  prometheusPort: string;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/** Empty-string defaults — unset values trigger fallback to built-in candidates. */
+export const DEFAULT_PROMETHEUS_CONFIG: PrometheusConfig = {
+  prometheusNamespace: '',
+  prometheusService: '',
+  prometheusPort: '',
+};
+
+/**
+ * Built-in fallback service candidates (backward-compatible with v1.1.0).
+ * Used when the user has not configured custom values.
+ */
+export const DEFAULT_PROMETHEUS_SERVICES: ReadonlyArray<{
+  namespace: string;
+  service: string;
+  port: string;
+}> = [
+  { namespace: 'monitoring', service: 'kube-prometheus-stack-prometheus', port: '9090' },
+  { namespace: 'monitoring', service: 'prometheus-operated', port: '9090' },
+  { namespace: 'monitoring', service: 'prometheus', port: '9090' },
+];
+
+// ---------------------------------------------------------------------------
+// ConfigStore
+// ---------------------------------------------------------------------------
+
+const PLUGIN_NAME = 'intel-gpu';
+
+export const prometheusConfigStore = new ConfigStore<PrometheusConfig>(PLUGIN_NAME);
+
+/**
+ * Returns the current Prometheus configuration, merged with defaults.
+ * Empty-string fields are treated as "not configured" and replaced by
+ * the corresponding default (empty string = use fallback candidates).
+ */
+export function getPrometheusConfig(): PrometheusConfig {
+  const stored = prometheusConfigStore.get();
+  return {
+    prometheusNamespace: stored?.prometheusNamespace ?? '',
+    prometheusService: stored?.prometheusService ?? '',
+    prometheusPort: stored?.prometheusPort ?? '',
+  };
+}
+
+/**
+ * Returns the ordered list of service candidates for Prometheus discovery.
+ *
+ * If the user has configured all three fields (namespace, service, port),
+ * that single candidate is tried first, followed by the built-in defaults
+ * as fallback.  If only some fields are configured, the configured values
+ * are still tried first (with defaults filling gaps), then the built-in
+ * defaults follow.
+ *
+ * This preserves backward compatibility: unconfigured deployments get the
+ * exact same candidate list as v1.1.0.
+ */
+export function getPrometheusServiceCandidates(): Array<{
+  namespace: string;
+  service: string;
+  port: string;
+}> {
+  const cfg = getPrometheusConfig();
+  const candidates: Array<{ namespace: string; service: string; port: string }> = [];
+
+  // If user configured a full custom service, try it first
+  if (cfg.prometheusNamespace && cfg.prometheusService && cfg.prometheusPort) {
+    candidates.push({
+      namespace: cfg.prometheusNamespace,
+      service: cfg.prometheusService,
+      port: cfg.prometheusPort,
+    });
+  }
+
+  // Always include the built-in defaults as fallback
+  for (const svc of DEFAULT_PROMETHEUS_SERVICES) {
+    candidates.push({ ...svc });
+  }
+
+  return candidates;
+}

--- a/src/components/MetricsPage.test.tsx
+++ b/src/components/MetricsPage.test.tsx
@@ -69,6 +69,10 @@ vi.mock('../api/metrics', () => ({
   formatWatts: (w: number) => `${w.toFixed(1)} W`,
   formatPercent: (used: number, max: number) =>
     max <= 0 ? '—' : `${Math.round((used / max) * 100)}%`,
+  getCheckedServicesDescription: vi.fn(
+    () =>
+      'kube-prometheus-stack-prometheus:9090 (monitoring namespace), prometheus-operated:9090 (monitoring namespace), prometheus:9090 (monitoring namespace)'
+  ),
 }));
 
 function makeContext(overrides: Partial<IntelGpuContextValue> = {}): IntelGpuContextValue {

--- a/src/components/MetricsPage.tsx
+++ b/src/components/MetricsPage.tsx
@@ -39,6 +39,7 @@ import {
   fetchGpuMetrics,
   formatPercent,
   formatWatts,
+  getCheckedServicesDescription,
   GpuChipMetrics,
   GpuMetrics,
 } from '../api/metrics';
@@ -277,8 +278,7 @@ export default function MetricsPage() {
               },
               {
                 name: 'Checked services',
-                value:
-                  'kube-prometheus-stack-prometheus:9090, prometheus-operated:9090, prometheus:9090 (monitoring namespace)',
+                value: getCheckedServicesDescription(),
               },
             ]}
           />

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SettingsPage from './SettingsPage';
+
+// Mock ConfigStore — vi.hoisted ensures mocks are available when vi.mock factory runs
+const { mockGet, mockSet, mockUpdate } = vi.hoisted(() => ({
+  mockGet: vi.fn(() => ({})),
+  mockSet: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  ConfigStore: vi.fn().mockImplementation(() => ({
+    get: mockGet,
+    set: mockSet,
+    update: mockUpdate,
+    useConfig: vi.fn(() => () => ({})),
+  })),
+}));
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockReturnValue({});
+  });
+
+  it('renders all three configuration fields', () => {
+    render(<SettingsPage />);
+    expect(screen.getByLabelText('Prometheus namespace')).toBeInTheDocument();
+    expect(screen.getByLabelText('Prometheus service name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Prometheus port')).toBeInTheDocument();
+  });
+
+  it('shows placeholder text with examples', () => {
+    render(<SettingsPage />);
+    expect(screen.getByPlaceholderText(/observability/)).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/monitoring-kube-prometheus-prometheus/)
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/9090/)).toBeInTheDocument();
+  });
+
+  it('loads values from ConfigStore when no data prop is provided', () => {
+    mockGet.mockReturnValue({
+      prometheusNamespace: 'observability',
+      prometheusService: 'monitoring-kube-prometheus-prometheus',
+      prometheusPort: '9090',
+    });
+    render(<SettingsPage />);
+    expect(screen.getByLabelText('Prometheus namespace')).toHaveValue('observability');
+    expect(screen.getByLabelText('Prometheus service name')).toHaveValue(
+      'monitoring-kube-prometheus-prometheus'
+    );
+    expect(screen.getByLabelText('Prometheus port')).toHaveValue('9090');
+  });
+
+  it('loads values from data prop when provided', () => {
+    render(
+      <SettingsPage
+        data={{
+          prometheusNamespace: 'myns',
+          prometheusService: 'mysvc',
+          prometheusPort: '9091',
+        }}
+      />
+    );
+    expect(screen.getByLabelText('Prometheus namespace')).toHaveValue('myns');
+    expect(screen.getByLabelText('Prometheus service name')).toHaveValue('mysvc');
+    expect(screen.getByLabelText('Prometheus port')).toHaveValue('9091');
+  });
+
+  it('calls ConfigStore.update when namespace changes', () => {
+    render(<SettingsPage />);
+    const input = screen.getByLabelText('Prometheus namespace');
+    fireEvent.change(input, { target: { value: 'observability' } });
+    expect(mockUpdate).toHaveBeenCalledWith({ prometheusNamespace: 'observability' });
+  });
+
+  it('calls ConfigStore.update when service name changes', () => {
+    render(<SettingsPage />);
+    const input = screen.getByLabelText('Prometheus service name');
+    fireEvent.change(input, { target: { value: 'my-prometheus' } });
+    expect(mockUpdate).toHaveBeenCalledWith({ prometheusService: 'my-prometheus' });
+  });
+
+  it('calls ConfigStore.update when port changes', () => {
+    render(<SettingsPage />);
+    const input = screen.getByLabelText('Prometheus port');
+    fireEvent.change(input, { target: { value: '9091' } });
+    expect(mockUpdate).toHaveBeenCalledWith({ prometheusPort: '9091' });
+  });
+
+  it('calls onDataChange when provided and a field changes', () => {
+    const onDataChange = vi.fn();
+    render(<SettingsPage onDataChange={onDataChange} />);
+    const input = screen.getByLabelText('Prometheus namespace');
+    fireEvent.change(input, { target: { value: 'observability' } });
+    expect(onDataChange).toHaveBeenCalledWith(
+      expect.objectContaining({ prometheusNamespace: 'observability' })
+    );
+  });
+
+  it('does not call onDataChange when not provided', () => {
+    render(<SettingsPage />);
+    const input = screen.getByLabelText('Prometheus namespace');
+    fireEvent.change(input, { target: { value: 'observability' } });
+    // No crash, ConfigStore.update still called
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it('shows blank fields when no config is stored', () => {
+    mockGet.mockReturnValue({});
+    render(<SettingsPage />);
+    expect(screen.getByLabelText('Prometheus namespace')).toHaveValue('');
+    expect(screen.getByLabelText('Prometheus service name')).toHaveValue('');
+    expect(screen.getByLabelText('Prometheus port')).toHaveValue('');
+  });
+
+  it('renders informational note about fallback behavior', () => {
+    render(<SettingsPage />);
+    expect(screen.getByText(/falls back/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,164 @@
+/**
+ * SettingsPage — Plugin settings for the intel-gpu Headlamp plugin.
+ *
+ * Allows users to configure the Prometheus service discovery parameters
+ * (namespace, service name, port) so the Metrics page works with
+ * non-default kube-prometheus-stack deployments.
+ *
+ * When all three fields are left blank, the plugin falls back to the
+ * built-in default candidates (monitoring/kube-prometheus-stack-prometheus:9090,
+ * monitoring/prometheus-operated:9090, monitoring/prometheus:9090),
+ * preserving backward compatibility.
+ */
+
+import { ConfigStore } from '@kinvolk/headlamp-plugin/lib';
+import { PluginSettingsDetailsProps } from '@kinvolk/headlamp-plugin/lib';
+import React, { useState } from 'react';
+import { PrometheusConfig } from '../api/pluginConfig';
+
+// ---------------------------------------------------------------------------
+// ConfigStore instance for reading/writing persisted settings
+// ---------------------------------------------------------------------------
+
+const configStore = new ConfigStore<PrometheusConfig>('intel-gpu');
+
+// ---------------------------------------------------------------------------
+// Input component
+// ---------------------------------------------------------------------------
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 12px',
+  border: '1px solid var(--mui-palette-divider, #ccc)',
+  borderRadius: '4px',
+  backgroundColor: 'var(--mui-palette-background-paper, #fff)',
+  color: 'var(--mui-palette-text-primary, #333)',
+  fontSize: '14px',
+  boxSizing: 'border-box',
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  marginBottom: '4px',
+  fontSize: '14px',
+  fontWeight: 500,
+  color: 'var(--mui-palette-text-primary, #333)',
+};
+
+const helpTextStyle: React.CSSProperties = {
+  fontSize: '12px',
+  color: 'var(--mui-palette-text-secondary, #666)',
+  marginTop: '4px',
+};
+
+// ---------------------------------------------------------------------------
+// Settings page
+// ---------------------------------------------------------------------------
+
+export default function SettingsPage({ data, onDataChange }: PluginSettingsDetailsProps) {
+  // Read current config from ConfigStore, falling back to data prop or defaults
+  const stored = configStore.get();
+  const initial: PrometheusConfig = {
+    prometheusNamespace: data?.prometheusNamespace ?? stored?.prometheusNamespace ?? '',
+    prometheusService: data?.prometheusService ?? stored?.prometheusService ?? '',
+    prometheusPort: data?.prometheusPort ?? stored?.prometheusPort ?? '',
+  };
+
+  const [namespace, setNamespace] = useState(initial.prometheusNamespace);
+  const [service, setService] = useState(initial.prometheusService);
+  const [port, setPort] = useState(initial.prometheusPort);
+
+  function handleChange(field: keyof PrometheusConfig, value: string): void {
+    const updated: PrometheusConfig = {
+      prometheusNamespace: field === 'prometheusNamespace' ? value : namespace,
+      prometheusService: field === 'prometheusService' ? value : service,
+      prometheusPort: field === 'prometheusPort' ? value : port,
+    };
+
+    // Update local state
+    if (field === 'prometheusNamespace') setNamespace(value);
+    if (field === 'prometheusService') setService(value);
+    if (field === 'prometheusPort') setPort(value);
+
+    // Persist to ConfigStore (readable by non-React code like metrics.ts)
+    configStore.update({ [field]: value } as Partial<PrometheusConfig>);
+
+    // Also notify Headlamp's plugin settings infrastructure
+    if (onDataChange) {
+      onDataChange(updated);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: '600px' }}>
+      <p style={{ ...helpTextStyle, marginBottom: '20px' }}>
+        Configure the Prometheus service used for GPU power metrics. Leave all fields blank to use
+        the default discovery (monitoring namespace, kube-prometheus-stack-prometheus /
+        prometheus-operated / prometheus, port 9090).
+      </p>
+
+      <div style={{ marginBottom: '16px' }}>
+        <label style={labelStyle} htmlFor="prometheus-namespace">
+          Prometheus Namespace
+        </label>
+        <input
+          id="prometheus-namespace"
+          type="text"
+          value={namespace}
+          onChange={e => handleChange('prometheusNamespace', e.target.value)}
+          placeholder="e.g. observability (blank = use defaults)"
+          style={inputStyle}
+          aria-label="Prometheus namespace"
+        />
+        <p style={helpTextStyle}>Kubernetes namespace where the Prometheus service is deployed.</p>
+      </div>
+
+      <div style={{ marginBottom: '16px' }}>
+        <label style={labelStyle} htmlFor="prometheus-service">
+          Prometheus Service Name
+        </label>
+        <input
+          id="prometheus-service"
+          type="text"
+          value={service}
+          onChange={e => handleChange('prometheusService', e.target.value)}
+          placeholder="e.g. monitoring-kube-prometheus-prometheus (blank = use defaults)"
+          style={inputStyle}
+          aria-label="Prometheus service name"
+        />
+        <p style={helpTextStyle}>Kubernetes Service name for the Prometheus instance.</p>
+      </div>
+
+      <div style={{ marginBottom: '16px' }}>
+        <label style={labelStyle} htmlFor="prometheus-port">
+          Prometheus Port
+        </label>
+        <input
+          id="prometheus-port"
+          type="text"
+          value={port}
+          onChange={e => handleChange('prometheusPort', e.target.value)}
+          placeholder="e.g. 9090 (blank = use defaults)"
+          style={inputStyle}
+          aria-label="Prometheus port"
+        />
+        <p style={helpTextStyle}>Port number or name for the Prometheus service.</p>
+      </div>
+
+      <div
+        style={{
+          padding: '12px',
+          backgroundColor: 'var(--mui-palette-background-default, #fafafa)',
+          borderRadius: '4px',
+          border: '1px solid var(--mui-palette-divider, #e0e0e0)',
+        }}
+      >
+        <p style={{ ...helpTextStyle, margin: 0 }}>
+          <strong>Note:</strong> The configured service is tried first. If it is unreachable, the
+          plugin falls back to the built-in default candidates. Changes take effect on the next
+          metrics fetch.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@
 
 import {
   registerDetailsViewSection,
+  registerPluginSettings,
   registerResourceTableColumnsProcessor,
   registerRoute,
   registerSidebarEntry,
@@ -27,6 +28,7 @@ import NodesPage from './components/NodesPage';
 import OverviewPage from './components/OverviewPage';
 import PodDetailSection from './components/PodDetailSection';
 import PodsPage from './components/PodsPage';
+import SettingsPage from './components/SettingsPage';
 
 // ---------------------------------------------------------------------------
 // Sidebar entries
@@ -180,3 +182,12 @@ registerResourceTableColumnsProcessor(({ id, columns }) => {
   }
   return columns;
 });
+
+// ---------------------------------------------------------------------------
+// Plugin settings — Prometheus service discovery configuration
+// Registers a settings page under Settings → Plugins → intel-gpu that
+// allows users to configure the Prometheus namespace/service/port for
+// non-default kube-prometheus-stack deployments.
+// ---------------------------------------------------------------------------
+
+registerPluginSettings('intel-gpu', SettingsPage, true);


### PR DESCRIPTION
# Summary
 
Replaces hardcoded Prometheus service discovery with configurable plugin
settings. Users can now specify the Prometheus namespace, service, and port
through Headlamp's settings UI, with backward-compatible fallback to the
original default candidates.
 
## Changes
 
- **`ConfigStore<PrometheusConfig>`** — uses Headlamp's real `ConfigStore<T>`
  API to persist user-configured namespace, service, and port
- **`registerPluginSettings`** — registers the settings schema so the
  UI renders a settings panel for the plugin
- **Runtime candidate resolution** — a fully configured custom candidate is
  tried first; if it fails, falls back to the original defaults:
  - `monitoring/kube-prometheus-stack-prometheus:9090`
  - `monitoring/prometheus-operated:9090`
  - `monitoring/prometheus:9090`
- **Settings UI** — added a settings panel component for configuring the
  Prometheus connection
- **Tests** — added metrics and settings tests (136/136 pass)
 
## Backward compatibility
 
If no settings are configured, discovery behavior is identical to before —
the same three fallback candidates are tried in the same order. Existing
installations require no configuration changes.
 
## Test plan
 
- [x] TypeScript compile passes
- [x] ESLint passes
- [x] Vitest: 136/136 tests pass
- [x] Plugin builds and packages successfully
- [x] Runtime read-only Prometheus API query verified via Kubernetes API proxy
- [x] Default fallback candidates preserved (no settings = original behavior)